### PR TITLE
catch interface errors

### DIFF
--- a/main.js
+++ b/main.js
@@ -196,8 +196,13 @@ class SmaEm extends utils.Adapter {
 			this.log.info('Details L1 ' + this.config.L1 + ' Details L2 ' + this.config.L2 + ' Details L3 ' + this.config.L3 + ' Extended Mode ' + this.config.ext + ' RealTime Interval ' + this.config.rtP + ' non-Realtime Interval ' + this.config.nrtP + ' Language: ' + language);
 
 			for (const dev of this.findIPv4IPs()) {
-				this.log.info(`Listen via UDP on Device ${dev.name} with IP ${dev.ipaddr} on Port ${this.config.BPO} for Multicast IP ${this.config.BIP}`);
-				client.addMembership(this.config.BIP, dev.ipaddr);
+				try {			
+					client.addMembership(this.config.BIP, dev.ipaddr);
+					this.log.info(`Listen via UDP on Device ${dev.name} with IP ${dev.ipaddr} on Port ${this.config.BPO} for Multicast IP ${this.config.BIP}`);
+				} catch (error){
+					this.log.debug(error);
+					this.log.info(`Drop Device ${dev.name} with IP ${dev.ipaddr}`);
+				}
 			}
 		});
 


### PR DESCRIPTION
Hab das Problem für mich gefixt sieht jetzt so aus:



```
sma-em.0 | 2023-07-01 17:22:54.280 | info | New device discovered: Sunny Home Manager 2.0 S/N: 3015986450 with IP/port: 192.168.178.128/49843 message rate: 1/sec
-- | -- | -- | --
sma-em.0 | 2023-07-01 17:22:52.220 | info | Drop Device eth0:4 with IP 192.168.179.4
sma-em.0 | 2023-07-01 17:22:52.219 | info | Drop Device eth0:3 with IP 192.168.179.3
sma-em.0 | 2023-07-01 17:22:52.218 | info | Drop Device eth0:2 with IP 192.168.179.2
sma-em.0 | 2023-07-01 17:22:52.217 | info | Drop Device eth0:1 with IP 192.168.179.1
sma-em.0 | 2023-07-01 17:22:52.214 | info | Listen via UDP on Device eth0 with IP 192.168.178.96 on Port 9522 for Multicast IP 239.12.255.254
sma-em.0 | 2023-07-01 17:22:52.212 | info | Details L1 false Details L2 false Details L3 false Extended Mode true RealTime Interval 1 non-Realtime Interval 30 Language: de
sma-em.0 | 2023-07-01 17:22:52.110 | info | starting. Version 0.7.0 (non-npm: ticaki/ioBroker.sma-em#b12bab229eb2f2523135994e9c637656c15780ad) in /opt/iobroker/node_modules/iobroker.sma-em, node: v18.16.1, js-controller: 5.0.5
```

bezieht sich auf: #552